### PR TITLE
Release v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pointless",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "An endless drawing canvas.",
   "dependencies": {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,7 +1,21 @@
+use std::path::{PathBuf, Path};
+use std::fs;
+
 use tauri::AppHandle;
 
-pub fn get_library_filename_path(handle: AppHandle) -> String {
-    let config_dir = handle.path_resolver().app_data_dir().unwrap();
+pub fn get_app_data_dir_path(handle: AppHandle) -> PathBuf {
+    return handle.path_resolver().app_data_dir().unwrap();
+}
 
-    format!("{}/library.dat", config_dir.display())
+pub fn get_library_dir_path(handle: AppHandle) -> String {
+    let config_dir = get_app_data_dir_path(handle);
+
+    return format!("{}/library", config_dir.display());
+}
+
+pub fn init(handle: AppHandle) {
+    let library_dir_path = get_library_dir_path(handle);
+    if !Path::new(&library_dir_path).exists() {
+        fs::create_dir_all(library_dir_path).unwrap();
+    }
 }

--- a/src-tauri/src/file.rs
+++ b/src-tauri/src/file.rs
@@ -1,5 +1,7 @@
-use std::io::{Write, Read};
+use std::io::{Write, Read, self};
 use std::fs::File;
+use std::fs;
+use std::path::Path;
 
 pub fn compress(filename: &str, contents: &str) -> bool {
     let mut writer = brotli::CompressorWriter::new(File::create(filename).unwrap(), 4096, 11, 22);
@@ -8,10 +10,26 @@ pub fn compress(filename: &str, contents: &str) -> bool {
     true
 }
 
-pub fn decompress(filename: &str) -> String {
-    let mut reader = brotli::Decompressor::new(File::open(filename).unwrap(), 4096);
+pub fn decompress<P: AsRef<Path>>(filename: P) -> Result<String, io::Error> {
+    let file = File::open(filename)?;
+    let mut reader = brotli::Decompressor::new(file, 4096);
     let mut data = String::new();
-    reader.read_to_string(&mut data).expect("Unable to decompress contents");
+    reader.read_to_string(&mut data)?;
 
-    data
+    Ok(data)
+}
+
+
+pub fn read_directory_contents(path: &str) -> Vec<String> {
+    let mut contents: Vec<String> = vec![];
+
+    for entry in fs::read_dir(path).unwrap() {
+        let file_name = entry.unwrap().file_name();
+        let file_name_str = file_name.to_str().unwrap().to_owned();
+        if !file_name_str.starts_with(".") {
+            contents.push(file_name_str);
+        }
+    }
+
+    contents
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,11 @@ mod file;
 fn main() {
     tauri::Builder::default()
         .menu(menu::init())
+        .setup(|app| {
+            let handle = app.handle();
+            config::init(handle);
+            Ok(())
+        })
         .invoke_handler(commands::get_handlers())
         .run(tauri::generate_context!())
         .expect("failed to run app");

--- a/src/components/Library/components/FolderListItem/index.js
+++ b/src/components/Library/components/FolderListItem/index.js
@@ -2,11 +2,16 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import InlineEdit from '../../../InlineEdit';
 import { ReactComponent as FolderIcon } from './../../../../assets/icons/folder.svg';
-import { deleteFolder, updateFolderName } from './../../../../reducers/library/librarySlice';
+import {
+  deleteFolder,
+  loadFolderContents,
+  updateFolderName,
+} from './../../../../reducers/library/librarySlice';
 import { store } from './../../../../store';
 import styles from './styles.module.css';
 import { ReactComponent as TrashcanIcon } from './../../../../assets/icons/trashcan.svg';
 import { confirm } from '@tauri-apps/api/dialog';
+import { useState } from 'react';
 
 function FolderListItem(props) {
   const onEditDone = (name) => {
@@ -21,6 +26,8 @@ function FolderListItem(props) {
   const onClick = (e) => {
     // Do not trigger the onClick when we click on a button.
     if (e.target.nodeName === 'BUTTON') return false;
+
+    store.dispatch(loadFolderContents(props.folder.id));
 
     props.onClick();
   };

--- a/src/components/Library/components/FolderListItem/index.js
+++ b/src/components/Library/components/FolderListItem/index.js
@@ -1,7 +1,9 @@
+import { confirm } from '@tauri-apps/api/dialog';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import InlineEdit from '../../../InlineEdit';
 import { ReactComponent as FolderIcon } from './../../../../assets/icons/folder.svg';
+import { ReactComponent as TrashcanIcon } from './../../../../assets/icons/trashcan.svg';
 import {
   deleteFolder,
   loadFolderContents,
@@ -9,9 +11,6 @@ import {
 } from './../../../../reducers/library/librarySlice';
 import { store } from './../../../../store';
 import styles from './styles.module.css';
-import { ReactComponent as TrashcanIcon } from './../../../../assets/icons/trashcan.svg';
-import { confirm } from '@tauri-apps/api/dialog';
-import { useState } from 'react';
 
 function FolderListItem(props) {
   const onEditDone = (name) => {

--- a/src/components/Paper/index.js
+++ b/src/components/Paper/index.js
@@ -1160,9 +1160,12 @@ class Paper extends React.Component {
         this.setState({ forceUpdate: true });
       }
 
-      attrs.viewBox = `${bbox.x - padding} ${bbox.y - padding} ${Math.round(
-        bbox.width + padding * 2,
-      )} ${Math.round(bbox.height + padding * 2)}`;
+      attrs.viewBox = [
+        bbox.x - padding,
+        bbox.y - padding,
+        Math.round(bbox.width + padding * 2),
+        Math.round(bbox.height + padding * 2),
+      ].join(' ');
       attrs.preserveAspectRatio = 'xMidYMid meet';
     } else {
       attrs.onTouchStart = this.canvasTouchStartHandler;

--- a/src/index.js
+++ b/src/index.js
@@ -6,15 +6,15 @@ import { Provider } from 'react-redux';
 import './assets/vendor/bootstrap/bootstrap-grid.min.css';
 import App from './components/App';
 import './index.css';
-import { loadLibrary } from './reducers/library/librarySlice';
+import { loadFolders } from './reducers/library/librarySlice';
 import { setAppVersion, setDarkMode, setPlatform } from './reducers/settings/settingsSlice';
 import reportWebVitals from './reportWebVitals';
 import { store } from './store';
 import { getVersion } from '@tauri-apps/api/app';
 
-// Load the library state on load.
-invoke('load_library').then((libraryState) => {
-  store.dispatch(loadLibrary(libraryState));
+// Load the library folders.
+invoke('load_library_folders').then((folders) => {
+  store.dispatch(loadFolders(folders));
 });
 
 // Get the current app version.

--- a/src/store.js
+++ b/src/store.js
@@ -14,7 +14,6 @@ const saveStateMiddleware = (store) => (next) => (action) => {
 
     // Auto-save the library for every library action.
     const whitelistedActions = [
-      'newPaperInFolder',
       'updateFolderName',
       'updatePaperName',
       'deleteFolder',


### PR DESCRIPTION
# Changes
This release contains a structure change. All folders and papers won't be saved in a single file `libary.dat` anymore, but rather in separate folders and paper files, like so:

```
~/Library/Application Support/com.pointless.app/library
├── 4d6a78cb-01fc-402e-b0dd-e07b134d8b54
│   ├── 2bb9172a-a96d-49df-9f12-69a5dd64b588.dat
│   ├── 3093ac0b-6e4d-494c-a72b-398c269c0c23.dat
│   └── folder_info.dat
└── 872a090b-e058-4861-85b9-2b3d64d48893
    ├── 5ba6ecca-ffb2-4d55-8455-9ab46c21da69.dat
    └── folder_info.dat
```

The first level inside the `library` folders contains the folders and each folder contains .dat paper files containing each individual paper data. The `folder_info.dat` contains the folder info like `name`, `createdAt`, `updatedAt`.

When the application loads, only the folder IDs along with the folder_info.dat files will be loaded. When the user clicks on a folder, only then the paper data will be retrieved. 

## Motivation
he motivation for this change is because active users that have lots of folders won't open the app to browse through all folders, but they rather click on one, maybe two folders to work in. Loading all the papers is thus unnecessary. Only loading the papers that the user needs is proper behavior.