### PR TITLE
Release v1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pointless",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "description": "An endless drawing canvas.",
   "dependencies": {

--- a/src/components/InlineEdit/index.js
+++ b/src/components/InlineEdit/index.js
@@ -33,6 +33,7 @@ class InlineEdit extends React.Component {
 
   onInputKeyPress = (e) => {
     if (e.which === KEY.ENTER) {
+      this.input.current.blur();
       this.toggleEdit(true);
     }
   };


### PR DESCRIPTION
This release fixes the bug where inline-edit input fields aren't blurred, resulting in the cursor showing as a text-cursor for anything clicked on after that. Blurring the input when pressing ENTER fixes this.