### PR TITLE
Release v1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pointless",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "description": "An endless drawing canvas.",
   "dependencies": {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -116,12 +116,33 @@ async fn save_library(handle: AppHandle, library_state: String) {
     }
 }
 
+#[tauri::command]
+async fn save_settings(handle: AppHandle, settings: String) {
+    let settings_filepath = config::get_settings_filepath(handle);
+    compress(&settings_filepath, &settings);
+}
+
+#[tauri::command]
+async fn load_settings(handle: AppHandle) -> Option<serde_json::Value> {
+    let settings_filepath = config::get_settings_filepath(handle);
+
+    if Path::new(&settings_filepath).exists() {
+        let contents = decompress(&settings_filepath).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&contents).expect("Unable to load settings");
+        return Some(json);
+    }
+
+    None
+}
+
 pub fn get_handlers() -> Box<dyn Fn(tauri::Invoke<tauri::Wry>) + Send + Sync> {
     Box::new(tauri::generate_handler![
         load_library_folders,
         load_library_folder_papers,
         delete_library_folder,
         delete_library_paper,
-        save_library
+        save_library,
+        load_settings,
+        save_settings
     ])
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -7,6 +7,12 @@ pub fn get_app_data_dir_path(handle: AppHandle) -> PathBuf {
     return handle.path_resolver().app_data_dir().unwrap();
 }
 
+pub fn get_settings_filepath(handle: AppHandle) -> String {
+    let app_data_dir = get_app_data_dir_path(handle);
+
+    return format!("{}/settings.dat", app_data_dir.display());
+}
+
 pub fn get_library_dir_path(handle: AppHandle) -> String {
     let config_dir = get_app_data_dir_path(handle);
 

--- a/src/components/Paper/index.js
+++ b/src/components/Paper/index.js
@@ -306,7 +306,7 @@ class Paper extends React.Component {
 
       case KEY.ZERO:
         if (this.state.scale !== 1) {
-          this.zoomToFit(1);
+          this.resetZoom();
         }
         break;
 
@@ -1135,7 +1135,7 @@ class Paper extends React.Component {
   };
 
   resetZoom = () => {
-    this.zoomToFit(1);
+    this.zoomBy(1 - this.state.scale);
   };
 
   drawCurrentShape = () => {

--- a/src/components/Paper/index.js
+++ b/src/components/Paper/index.js
@@ -42,6 +42,7 @@ import {
 } from './helpers';
 import styles from './styles.module.css';
 import { isEqual } from '../../helpers';
+import { setPreferredLinewidth } from '../../reducers/settings/settingsSlice';
 
 const getInitialState = (isDarkMode, args) => ({
   userLastActiveAt: new Date().toISOString(),
@@ -101,6 +102,7 @@ class Paper extends React.Component {
     this.ctx = null;
     this.state = getInitialState(props.isDarkMode, {
       shapes: props.paper.shapes,
+      linewidth: props.preferredLinewidth,
     });
   }
 
@@ -961,6 +963,7 @@ class Paper extends React.Component {
 
   changeLinewidth = (linewidth) => {
     this.setState({ linewidth });
+    this.props.dispatch(setPreferredLinewidth(linewidth));
   };
 
   setMode = (mode) => {
@@ -1353,6 +1356,7 @@ function mapStateToProps(state, props) {
     paper: state.library.papers.find((paper) => paper.id === props.paperId),
     isDarkMode: state.settings.isDarkMode,
     platform: state.settings.platform,
+    preferredLinewidth: state.settings.canvasPreferredLinewidth,
   };
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,5 +23,11 @@ export const KEY = {
   BACKSPACE: 8,
 };
 
+export const SORT_BY = {
+  NAME_AZ: 1,
+  NAME_ZA: 2,
+  LAST_EDIT: 3,
+};
+
 export const BASE_DIR = BaseDirectory.App;
 export const EXPORTS_DIR = BaseDirectory.Download;

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,28 @@ import './assets/vendor/bootstrap/bootstrap-grid.min.css';
 import App from './components/App';
 import './index.css';
 import { loadFolders } from './reducers/library/librarySlice';
-import { setAppVersion, setDarkMode, setPlatform } from './reducers/settings/settingsSlice';
+import {
+  loadSettings,
+  setAppVersion,
+  setDarkMode,
+  setPlatform,
+} from './reducers/settings/settingsSlice';
 import reportWebVitals from './reportWebVitals';
 import { store } from './store';
 import { getVersion } from '@tauri-apps/api/app';
 
 // Load the library folders.
 invoke('load_library_folders').then((folders) => {
-  store.dispatch(loadFolders(folders));
+  if (folders) {
+    store.dispatch(loadFolders(folders));
+  }
+});
+
+// Load the saved user settings.
+invoke('load_settings').then((settings) => {
+  if (settings) {
+    store.dispatch(loadSettings(settings));
+  }
 });
 
 // Get the current app version.

--- a/src/reducers/settings/settingsSlice.js
+++ b/src/reducers/settings/settingsSlice.js
@@ -1,9 +1,14 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { LINEWIDTH } from '../../components/Paper/constants';
+import { SORT_BY } from '../../constants';
+import { invoke } from '@tauri-apps/api';
 
 const initialState = {
   isDarkMode: window.matchMedia('(prefers-color-scheme: dark)'),
   platform: null,
   appVersion: null,
+  sortPapersBy: SORT_BY.NAME_AZ,
+  canvasPreferredLinewidth: LINEWIDTH.SMALL,
 };
 
 const settingsSlice = createSlice({
@@ -19,9 +24,43 @@ const settingsSlice = createSlice({
     setAppVersion: (state, action) => {
       state.appVersion = action.payload;
     },
+    setPreferredLinewidth: (state, action) => {
+      state.canvasPreferredLinewidth = action.payload;
+    },
+    setSortPapersBy: (state, action) => {
+      state.sortPapersBy = action.payload;
+    },
+    loadSettings: (state, action) => {
+      if (action.payload && typeof action.payload === 'object') {
+        if (Object.values(SORT_BY).includes(action.payload.sortPapersBy)) {
+          state.sortPapersBy = action.payload.sortPapersBy;
+        }
+
+        if (Object.values(LINEWIDTH).includes(action.payload.canvasPreferredLinewidth)) {
+          state.canvasPreferredLinewidth = action.payload.canvasPreferredLinewidth;
+        }
+      }
+    },
   },
 });
 
-export const { setDarkMode, setPlatform, setAppVersion } = settingsSlice.actions;
+export const saveSettings = () => async (dispatch, getState) => {
+  const { sortPapersBy, canvasPreferredLinewidth } = getState().settings;
+  const settings = {
+    sortPapersBy,
+    canvasPreferredLinewidth,
+  };
+
+  await invoke('save_settings', { settings: JSON.stringify(settings) });
+};
+
+export const {
+  setDarkMode,
+  setPlatform,
+  setAppVersion,
+  loadSettings,
+  setSortPapersBy,
+  setPreferredLinewidth,
+} = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -3,7 +3,7 @@ import thunkMiddleware from 'redux-thunk';
 import libraryReducer, { saveLibrary } from './reducers/library/librarySlice';
 import paperReducer from './reducers/paper/paperSlice';
 import routerReducer from './reducers/router/routerSlice';
-import settingsReducer from './reducers/settings/settingsSlice';
+import settingsReducer, { saveSettings } from './reducers/settings/settingsSlice';
 
 const saveStateMiddleware = (store) => (next) => (action) => {
   const result = next(action);
@@ -28,6 +28,24 @@ const saveStateMiddleware = (store) => (next) => (action) => {
   return result;
 };
 
+const saveSettingsMiddleware = (store) => (next) => (action) => {
+  const result = next(action);
+
+  if (typeof action === 'object') {
+    const reducerName = action.type.split('/')[0];
+    const actionName = action.type.split('/')[1];
+
+    // Auto-save the library for every library action.
+    const whitelistedActions = ['setSortPapersBy', 'setPreferredLinewidth'];
+
+    if (reducerName === 'settings' && whitelistedActions.includes(actionName)) {
+      store.dispatch(saveSettings());
+    }
+  }
+
+  return result;
+};
+
 function configureAppStore() {
   const store = configureStore({
     reducer: {
@@ -36,7 +54,7 @@ function configureAppStore() {
       router: routerReducer,
       library: libraryReducer,
     },
-    middleware: [saveStateMiddleware, thunkMiddleware],
+    middleware: [saveStateMiddleware, saveSettingsMiddleware, thunkMiddleware],
   });
 
   return store;


### PR DESCRIPTION
This release adds:
- settings persistence for:
  - the selected sortBy in the library
  - the selected canvas linewidth
- sort folders always be name a-z
- adjust reset-zoom (ctrl+0) logic to only scale back to 100%, rather than `zoomToFit(1)`